### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sonarscan.yaml
+++ b/.github/workflows/sonarscan.yaml
@@ -1,4 +1,6 @@
 name: project cicd flow
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Seema82/spring-boot-Java-appl_githubaction/security/code-scanning/2](https://github.com/Seema82/spring-boot-Java-appl_githubaction/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimum permissions required for the workflow to function correctly. Based on the workflow's steps, it primarily reads repository contents and uses secrets for SonarQube analysis. Therefore, the `contents: read` permission is sufficient. No write permissions are needed.

The `permissions` block will be added immediately after the `name` field in the workflow file to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
